### PR TITLE
Feat/infinity scroll

### DIFF
--- a/src/components/common/Item/Item.tsx
+++ b/src/components/common/Item/Item.tsx
@@ -1,15 +1,28 @@
 import { faHeart } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-// import Image from "next/image";
 import style from "./item.module.css";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { useRouter } from "next/router";
+import useIntersectionObserver from "../../../hooks/useIntersectionObserver";
 
-export default function Item({ id, img, title, content, author, heartNum }) {
+export default function Item({ isLastItem, onFetchMore, ...props }) {
   const router = useRouter();
+  const { id, img, title, content, author, heartNum } = props;
+
+  const ref = useRef<HTMLDivElement | null>(null);
+  const entry = useIntersectionObserver(ref, {});
+  const isIntersecting = !!entry?.isIntersecting;
+
+  useEffect(() => {
+    isLastItem && isIntersecting && onFetchMore();
+  }, [isLastItem, isIntersecting]);
 
   return (
-    <div className={style.item} onClick={() => router.push(`/detail/${id}`)}>
+    <div
+      ref={ref}
+      className={style.item}
+      onClick={() => router.push(`/detail/${id}`)}
+    >
       <img
         alt="임시대표이미지"
         src="./images/IMG_7631.jpg"

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,19 +1,22 @@
 import { useEffect, useRef, useState } from "react";
 
 const useInfiniteScroll = (data) => {
-  const [page, setPage] = useState(0);
+  // const [page, setPage] = useState(1);
   // const [noMoreData, setNoMoreData] = useState(false);
+  const page = useRef(1);
 
   const loaderRef = useRef<HTMLDivElement>(null);
   const observer = useRef<IntersectionObserver | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const handleObserver = (entries: IntersectionObserverEntry[]) => {
+  const handleObserver = async (entries: IntersectionObserverEntry[]) => {
     const target = entries[0];
     if (target.isIntersecting && !loading) {
-      setLoading(true);
-      if (data.length > 0 && !loading) {
-        setPage((prev) => prev + 1);
+      await setLoading(true);
+      await setLoading(false);
+
+      if (data.length > 0) {
+        page.current += 1;
       }
     }
   };
@@ -36,7 +39,7 @@ const useInfiniteScroll = (data) => {
         observer.current.disconnect();
       }
     };
-  }, [data]);
+  }, [data, page.current]);
 
   return { page, loaderRef, loading, setLoading };
 };

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,47 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 
-const useInfiniteScroll = (data) => {
-  // const [page, setPage] = useState(1);
-  // const [noMoreData, setNoMoreData] = useState(false);
-  const page = useRef(1);
-
-  const loaderRef = useRef<HTMLDivElement>(null);
-  const observer = useRef<IntersectionObserver | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  const handleObserver = async (entries: IntersectionObserverEntry[]) => {
-    const target = entries[0];
-    if (target.isIntersecting && !loading) {
-      await setLoading(true);
-      await setLoading(false);
-
-      if (data.length > 0) {
-        page.current += 1;
-      }
-    }
-  };
-
-  useEffect(() => {
-    const options = {
-      root: null,
-      rootMargin: "20px",
-      threshold: 1.0,
-    };
-
-    observer.current = new IntersectionObserver(handleObserver, options);
-
-    if (loaderRef.current) {
-      observer.current.observe(loaderRef.current);
-    }
-
-    return () => {
-      if (observer.current) {
-        observer.current.disconnect();
-      }
-    };
-  }, [data, page.current]);
-
-  return { page, loaderRef, loading, setLoading };
-};
+const useInfiniteScroll = () => {};
 
 export default useInfiniteScroll;

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,5 +1,0 @@
-import { useEffect, useRef, useState } from "react";
-
-const useInfiniteScroll = () => {};
-
-export default useInfiniteScroll;

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 
 const useInfiniteScroll = (data) => {
   const [page, setPage] = useState(0);
-  const [noMoreData, setNoMoreData] = useState(false);
+  // const [noMoreData, setNoMoreData] = useState(false);
 
   const loaderRef = useRef<HTMLDivElement>(null);
   const observer = useRef<IntersectionObserver | null>(null);
@@ -10,7 +10,7 @@ const useInfiniteScroll = (data) => {
 
   const handleObserver = (entries: IntersectionObserverEntry[]) => {
     const target = entries[0];
-    if (target.isIntersecting && !loading && !noMoreData) {
+    if (target.isIntersecting && !loading) {
       setLoading(true);
       if (data.length > 0 && !loading) {
         setPage((prev) => prev + 1);
@@ -38,7 +38,7 @@ const useInfiniteScroll = (data) => {
     };
   }, [data]);
 
-  return {};
+  return { page, loaderRef, loading, setLoading };
 };
 
 export default useInfiniteScroll;

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,44 @@
+import { RefObject, useEffect, useState } from "react";
+
+function useIntersectionObserver(
+  targetRef: RefObject<Element>,
+  options: IntersectionObserverInit = {
+    threshold: 0,
+    root: null,
+    rootMargin: "0px",
+  }
+): IntersectionObserverEntry | undefined {
+  const [entry, setEntry] = useState<IntersectionObserverEntry>();
+
+  const isIntersecting = entry?.isIntersecting;
+
+  const updateEntry = (entries: IntersectionObserverEntry[]): void => {
+    const [entry] = entries;
+
+    setEntry(entry);
+  };
+
+  useEffect(() => {
+    const target = targetRef?.current;
+
+    if (isIntersecting || !target) return;
+
+    const observer = new IntersectionObserver(updateEntry, options);
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    targetRef,
+    options.root,
+    options.rootMargin,
+    options.threshold,
+    isIntersecting,
+  ]);
+
+  return entry;
+}
+
+export default useIntersectionObserver;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,21 +5,27 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import Nav from "../components/Nav/Nav";
 import React from "react";
+import useInfiniteScroll from "../hooks/useInfiniteScroll";
 //
 
 export default function Main() {
   const [itemListData, setItemListData] = useState([]);
+  const { page, loaderRef, loading, setLoading } =
+    useInfiniteScroll(itemListData);
+
   useEffect(() => {
     axios
-      // .get("/data/MAIN_LIST_DATA.json")
       .get("http://falsystack.jp:8080/posts")
       .then((data) => {
-        setItemListData(data.data);
+        setItemListData([...itemListData, ...data.data]);
       })
       .catch((error) => {
         console.log(error);
+      })
+      .finally(() => {
+        setLoading(false);
       });
-  }, []);
+  }, [page]);
 
   return (
     <>
@@ -45,6 +51,12 @@ export default function Main() {
             />
           );
         })}
+
+        {loading && <div>loading...</div>}
+        <div
+          ref={loaderRef}
+          style={{ height: "100px", background: "transparent" }}
+        />
       </div>
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -51,23 +51,13 @@ export default function Main() {
                 onFetchMore={() => setPage((prev) => prev + 1)}
                 isLastItem={itemListData.length - 1 === idx}
                 key={item.id}
-                // id={item.id}
-                // img={item.img}
-                // title={item.title}
-                // content={item.content}
-                // author={item.author}
-                // heartNum={item.heartNum}
                 {...item}
               />
             );
           })}
         </div>
 
-        {/* {itemListData.length > 0 && loading ? (
-          <div ref={ref}>스크롤 loading ...</div>
-        ) : (
-          <div>loading</div>
-        )} */}
+        {!isLastItem && <div>loading</div>}
       </div>
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,6 @@ import axios from "axios";
 import Nav from "../components/Nav/Nav";
 import React from "react";
 import useInfiniteScroll from "../hooks/useInfiniteScroll";
-//
 
 export default function Main() {
   const [itemListData, setItemListData] = useState([]);
@@ -19,7 +18,7 @@ export default function Main() {
     axios
       .get(`${baseUrl}/posts`)
       .then((data) => {
-        setItemListData([...itemListData, ...data.data]);
+        setItemListData((prevData) => [...prevData, ...data.data]);
       })
       .catch((error) => {
         console.log(error);
@@ -27,7 +26,10 @@ export default function Main() {
       .finally(() => {
         setLoading(false);
       });
-  }, [page]);
+  }, [page.current]);
+
+  console.log("page", page.current);
+  console.log("loading", loading);
 
   return (
     <>


### PR DESCRIPTION
## 1. 해당 브랜치에서 작업한 내용
- 무한스크롤 기능
- intersection observer만 hook으로 분리

## 2. 작업한 결과물
![blog_무한스크롤_성공](https://github.com/hjyang369/my-blog/assets/125977702/29be1813-2ab2-4af9-8497-51a2d6857381)


## 3. 해당 작업을 하면서 생겼던 이슈사항
- 관심사 분리 위해 hook으로 코드 분리 후 page의 값이 갱신이 안되는 문제 발생
   - 렌더링이 되면서 page 값이 초기화 되는 문제라고 생각해 page를 useRef 이용해 값을 유지하려고 해보았으나 같은 문제 발생
   - 다시 확인해보니 setPage 함수가 작동하지 않는 것을 발견함
   - 데이터를 받아왔을때 = 데이터를 받아온 배열 상태의 길이가 1 이상일 때 page 값을 변경하도록 코드를 작성해두었는데 배열 상태의 길이가 비동기로 업데이트 되면서 즉시 변경되지 않아 page 값이 변경되지 않았고 그래서 api 요청이 안 가는 것을 확인했음. 한번씩 api가 동작했던 것은 배열 상태의 길이가 비동기로 업데이트 되었을 때 밀려있던 요청이 와라락 갔던 것
   - 배열 상태의 길이를 useRef로 관리해보았으나 같은 문제 발생
   - 배열 상태의 길이를 사용하지 않는 방법으로 무한스크롤을 hook으로 구현하기 위해 코드 새로 작성
   - intersection observer만 hook으로 분리 후 api 호출은 부모 component 에서, ref 생성 및 observer 적용은 자식 component에서 실행하는 것으로 코드 재구성함


## 4. 해당 작업을 통해 알게 된 내용
- 관심사 분리에서 어디서부터 어디까지가 관심사가 동일한지 판별하고 hook 분리하기
- IntersectionObserver