### PR TITLE
feat: firebase 로그인 기능 구현

### DIFF
--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,5 +1,3 @@
-import style from "./nav.module.css";
-//
 import { useRouter } from "next/router";
 import IC_User from "../../../public/icon/User";
 import useMoveToPage from "../../hooks/useMovetoPage";
@@ -8,6 +6,8 @@ import IC_Like from "../../../public/icon/Like";
 import ClickButton from "../common/clickButton";
 import Logo from "../common/logo";
 import { logoutUser } from "../../pages/api/auth";
+import { useSetRecoilState } from "recoil";
+import { userState } from "../../store/userStore";
 
 type NaveProps = {
   postWriting?: () => void;
@@ -20,12 +20,27 @@ export default function Nav({ postWriting, isWriting }: NaveProps) {
   const isResume = router.pathname === "/resume";
   const currentTab = isResume ? "블로그" : "이력서";
   const { moveToPage } = useMoveToPage();
+  const setUser = useSetRecoilState(userState);
 
   const handleCurrentTab = () => {
     if (isResume) {
       moveToPage("/");
     } else {
       moveToPage("/resume");
+    }
+  };
+
+  const logout = () => {
+    const confirmation = window.confirm("로그아웃 하시겠습니까?");
+    if (confirmation) {
+      logoutUser().then(() => {
+        setUser({
+          user_email: "",
+          user_nickname: "",
+          user_uid: "",
+        });
+        moveToPage("/");
+      });
     }
   };
 
@@ -69,7 +84,7 @@ export default function Nav({ postWriting, isWriting }: NaveProps) {
         >
           <IC_User />
         </button>
-        <button onClick={logoutUser}>로그아웃</button>
+        <button onClick={logout}>로그아웃</button>
       </div>
     </nav>
   );

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -9,7 +9,6 @@ import { logoutUser } from "../../pages/api/auth";
 import { useRecoilState } from "recoil";
 import { userState } from "../../store/userStore";
 import { useState } from "react";
-import useCheckUser from "../../hooks/useCheckUser";
 
 type NaveProps = {
   postWriting?: () => void;
@@ -98,8 +97,12 @@ export default function Nav({ postWriting, isWriting }: NaveProps) {
         >
           <IC_User />
         </button>
-        <button onClick={handleLogin} suppressHydrationWarning={true}>
-          {isLogin ? "로그아웃" : "로그인"}
+        <button
+          onClick={handleLogin}
+          suppressHydrationWarning={true}
+          className="bg-yellow200 text-xl text-main font-bold"
+        >
+          {isLogin ? "logout" : "login"}
         </button>
       </div>
     </nav>

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -6,8 +6,10 @@ import IC_Like from "../../../public/icon/Like";
 import ClickButton from "../common/clickButton";
 import Logo from "../common/logo";
 import { logoutUser } from "../../pages/api/auth";
-import { useSetRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 import { userState } from "../../store/userStore";
+import { useState } from "react";
+import useCheckUser from "../../hooks/useCheckUser";
 
 type NaveProps = {
   postWriting?: () => void;
@@ -16,17 +18,29 @@ type NaveProps = {
 
 export default function Nav({ postWriting, isWriting }: NaveProps) {
   const router = useRouter();
-
   const isResume = router.pathname === "/resume";
   const currentTab = isResume ? "블로그" : "이력서";
   const { moveToPage } = useMoveToPage();
-  const setUser = useSetRecoilState(userState);
+  const [user, setUser] = useRecoilState(userState);
+  const [isLogin, setIsLogin] = useState(Boolean(user.user_uid));
 
   const handleCurrentTab = () => {
     if (isResume) {
       moveToPage("/");
     } else {
       moveToPage("/resume");
+    }
+  };
+
+  const handleLogin = () => {
+    if (isLogin) {
+      //로그인 상태
+      setIsLogin(false);
+      logout();
+    } else {
+      //로그아웃 상태
+      setIsLogin(true);
+      moveToPage("/login");
     }
   };
 
@@ -84,7 +98,9 @@ export default function Nav({ postWriting, isWriting }: NaveProps) {
         >
           <IC_User />
         </button>
-        <button onClick={logout}>로그아웃</button>
+        <button onClick={handleLogin} suppressHydrationWarning={true}>
+          {isLogin ? "로그아웃" : "로그인"}
+        </button>
       </div>
     </nav>
   );

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -7,6 +7,7 @@ import IC_AddPost from "../../../public/icon/AddPost";
 import IC_Like from "../../../public/icon/Like";
 import ClickButton from "../common/clickButton";
 import Logo from "../common/logo";
+import { logoutUser } from "../../pages/api/auth";
 
 type NaveProps = {
   postWriting?: () => void;
@@ -68,6 +69,7 @@ export default function Nav({ postWriting, isWriting }: NaveProps) {
         >
           <IC_User />
         </button>
+        <button onClick={logoutUser}>로그아웃</button>
       </div>
     </nav>
   );

--- a/src/hooks/useCheckUser.ts
+++ b/src/hooks/useCheckUser.ts
@@ -1,8 +1,11 @@
 import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { logoutUser } from "../pages/api/auth";
 import useMoveToPage from "./useMovetoPage";
+import { useSetRecoilState } from "recoil";
+import { userState } from "../store/userStore";
 
 const useCheckUser = () => {
+  const setUser = useSetRecoilState(userState);
   const { moveToPage } = useMoveToPage();
 
   const auth = getAuth();
@@ -11,14 +14,29 @@ const useCheckUser = () => {
   const isLoggedIn = () => {
     onAuthStateChanged(auth, (user) => {
       if (user) {
-        // 사용자 로그인 시 동작
+        // 사용자 로그인 되어있을 시 동작
         console.log(user.uid);
         return;
       }
       // 사용자 로그아웃 시 동작
       console.log("logout");
-      logoutUser();
-      moveToPage("/login");
+      logoutUser().then(() => {
+        setUser({
+          user_email: "",
+          user_nickname: "",
+          user_uid: "",
+        });
+      });
+
+      const confirmation = window.confirm(
+        "로그인 기간이 만료되었습니다. 다시 로그인 하시겠습니까?"
+      );
+
+      if (confirmation) {
+        moveToPage("/login");
+      } else {
+        moveToPage("/");
+      }
     });
   };
 

--- a/src/hooks/useCheckUser.ts
+++ b/src/hooks/useCheckUser.ts
@@ -16,7 +16,7 @@ const useCheckUser = () => {
       if (user) {
         // 사용자 로그인 되어있을 시 동작
         console.log(user.uid);
-        return;
+        return user.uid;
       }
       // 사용자 로그아웃 시 동작
       console.log("logout");

--- a/src/hooks/useCheckUser.ts
+++ b/src/hooks/useCheckUser.ts
@@ -1,0 +1,28 @@
+import { getAuth, onAuthStateChanged } from "firebase/auth";
+import { logoutUser } from "../pages/api/auth";
+import useMoveToPage from "./useMovetoPage";
+
+const useCheckUser = () => {
+  const { moveToPage } = useMoveToPage();
+
+  const auth = getAuth();
+  const user = auth.currentUser;
+
+  const isLoggedIn = () => {
+    onAuthStateChanged(auth, (user) => {
+      if (user) {
+        // 사용자 로그인 시 동작
+        console.log(user.uid);
+        return;
+      }
+      // 사용자 로그아웃 시 동작
+      console.log("logout");
+      logoutUser();
+      moveToPage("/login");
+    });
+  };
+
+  return { isLoggedIn };
+};
+
+export default useCheckUser;

--- a/src/hooks/useCheckUser.ts
+++ b/src/hooks/useCheckUser.ts
@@ -29,7 +29,7 @@ const useCheckUser = () => {
       });
 
       const confirmation = window.confirm(
-        "로그인 기간이 만료되었습니다. 다시 로그인 하시겠습니까?"
+        "로그인이 필요한 페이지입니다. 로그인을 해주세요."
       );
 
       if (confirmation) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,8 @@ import { RecoilRoot } from "recoil";
 import "../firebase/index";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useEffect } from "react";
+import { logoutUser } from "./api/auth";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -19,6 +21,18 @@ const queryClient = new QueryClient({
 });
 
 const App = ({ Component, pageProps }) => {
+  //탭 닫으면 로그아웃
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      logoutUser();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <RecoilRoot>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,7 +24,7 @@ export default function Main() {
   const { startDate, lastDate } = dateTitle;
   const [currentSort, setCurrentSort] = useRecoilState(mainSortState);
   const user = useRecoilValue(userState); // 새로고침하더라고 지속적으로 user 정보가 저장되어있어야함
-  console.log(user);
+  // console.log(user);
 
   const changeSort = (value: string) => {
     setItemListData([]);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,6 @@ import { idState } from "../store/savePostStore";
 import { useRecoilState } from "recoil";
 import Filter from "../components/Filter";
 import { mainFilterTitleState, mainSortState } from "../store/mainFilterStore";
-import useMoveToPage from "../hooks/useMovetoPage";
 import { getReady } from "../modules/function";
 
 export default function Main() {
@@ -23,7 +22,6 @@ export default function Main() {
   const { dateTitle, tagTitle, contentTitle } = filterTitle;
   const { startDate, lastDate } = dateTitle;
   const [currentSort, setCurrentSort] = useRecoilState(mainSortState);
-  const { moveToPage } = useMoveToPage();
 
   const changeSort = (value: string) => {
     setItemListData([]);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,10 +7,11 @@ import Nav from "../components/Nav/Nav";
 import React from "react";
 import { PostDataType } from "../types/post";
 import { idState } from "../store/savePostStore";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import Filter from "../components/Filter";
 import { mainFilterTitleState, mainSortState } from "../store/mainFilterStore";
 import { getReady } from "../modules/function";
+import { userState } from "../store/userStore";
 
 export default function Main() {
   const [itemListData, setItemListData] = useState([]);
@@ -22,6 +23,8 @@ export default function Main() {
   const { dateTitle, tagTitle, contentTitle } = filterTitle;
   const { startDate, lastDate } = dateTitle;
   const [currentSort, setCurrentSort] = useRecoilState(mainSortState);
+  const user = useRecoilValue(userState); // 새로고침하더라고 지속적으로 user 정보가 저장되어있어야함
+  console.log(user);
 
   const changeSort = (value: string) => {
     setItemListData([]);

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -10,7 +10,6 @@ import useMoveToPage from "../../hooks/useMovetoPage";
 import { getReady } from "../../modules/function";
 import { loginUserEmail } from "../api/auth";
 import { userState } from "../../store/userStore";
-import { userType } from "../../types/user";
 
 const initInputValue = {
   email: "",
@@ -29,8 +28,14 @@ export default function Login() {
 
   const loginUser = async (email, password) => {
     const user = await loginUserEmail(email, password);
-    setUser(user as userType);
-    moveToPage("/");
+    if (user) {
+      setUser({
+        user_email: user?.user_email,
+        user_nickname: user?.user_nickname,
+        user_uid: user?.user_uid,
+      });
+      moveToPage("/");
+    }
   };
 
   const LOGIN_BUTTON_DATA = [

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,3 +1,4 @@
+import { useSetRecoilState } from "recoil";
 import IC_Lock from "../../../public/icon/Lock";
 import IC_User from "../../../public/icon/User";
 import BlackButton from "../../components/common/blackButton";
@@ -7,20 +8,30 @@ import Logo from "../../components/common/logo";
 import useInputValue from "../../hooks/useInputValue";
 import useMoveToPage from "../../hooks/useMovetoPage";
 import { getReady } from "../../modules/function";
+import { loginUserEmail } from "../api/auth";
+import { userState } from "../../store/userStore";
+import { userType } from "../../types/user";
 
 const initInputValue = {
-  name: "",
+  email: "",
   password: "",
 };
 
 const LOGIN_INPUT_DATA = [
-  { id: 1, name: "name", type: "text", icon: <IC_User /> },
+  { id: 1, name: "email", type: "text", icon: <IC_User /> },
   { id: 2, name: "password", type: "password", icon: <IC_Lock /> },
 ];
 
 export default function Login() {
   const { inputValue, handleInput } = useInputValue(initInputValue);
   const { moveToPage } = useMoveToPage();
+  const setUser = useSetRecoilState(userState);
+
+  const loginUser = async (email, password) => {
+    const user = await loginUserEmail(email, password);
+    setUser(user as userType);
+    moveToPage("/");
+  };
 
   const LOGIN_BUTTON_DATA = [
     { id: 1, text: "아이디 찾기", func: getReady },
@@ -29,7 +40,11 @@ export default function Login() {
   ];
 
   const LOGIN_TYPE_DATA = [
-    { id: 1, text: "로그인", func: getReady },
+    {
+      id: 1,
+      text: "로그인",
+      func: () => loginUser(inputValue.email, inputValue.password),
+    },
     { id: 2, text: "카카오 로그인", func: getReady },
   ];
 

--- a/src/pages/writing/index.tsx
+++ b/src/pages/writing/index.tsx
@@ -17,6 +17,10 @@ const MDEditor = dynamic(() => import("@uiw/react-md-editor"), {
 });
 
 export default function Writing() {
+  useEffect(() => {
+    isLoggedIn();
+  }, []);
+
   const initInputValue: WritingInputValueType = {
     title: "",
     tag: "",
@@ -107,9 +111,6 @@ export default function Writing() {
       setTags(updatedTags);
     }
   };
-  useEffect(() => {
-    isLoggedIn();
-  }, []);
 
   return (
     <>

--- a/src/pages/writing/index.tsx
+++ b/src/pages/writing/index.tsx
@@ -3,12 +3,13 @@ import style from "./writing.module.css";
 import useInputValue from "../../hooks/useInputValue";
 import axios from "axios";
 import Nav from "../../components/Nav/Nav";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import React from "react";
 import { WritingInputValueType } from "../../types/post";
 import useMoveToPage from "../../hooks/useMovetoPage";
 import ClickTag from "../../components/common/clickTag";
 import dynamic from "next/dynamic";
+import useCheckUser from "../../hooks/useCheckUser";
 // import { addPost } from "../api/post"; //FIREBASE
 
 const MDEditor = dynamic(() => import("@uiw/react-md-editor"), {
@@ -28,6 +29,7 @@ export default function Writing() {
   const [markdown, setMarkDown] = useState("");
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
   const { moveToPage } = useMoveToPage();
+  const { isLoggedIn } = useCheckUser();
 
   const postingFuncData = {
     title: inputValue.title,
@@ -103,6 +105,9 @@ export default function Writing() {
       setTags(updatedTags);
     }
   };
+  useEffect(() => {
+    isLoggedIn();
+  }, []);
 
   return (
     <>

--- a/src/pages/writing/index.tsx
+++ b/src/pages/writing/index.tsx
@@ -30,6 +30,8 @@ export default function Writing() {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
   const { moveToPage } = useMoveToPage();
   const { isLoggedIn } = useCheckUser();
+  // const user = useRecoilValue(userState);
+  // console.log(user);
 
   const postingFuncData = {
     title: inputValue.title,

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -17,7 +17,7 @@ export const userState = atom<userType>({
   default: {
     user_email: "",
     user_nickname: "",
-    user_resume: "",
+    // user_resume: "",
     user_uid: "",
   },
   effects_UNSTABLE: [persistAtom],

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,0 +1,24 @@
+import { RecoilEnv, atom } from "recoil";
+import { userType } from "../types/user";
+import { recoilPersist } from "recoil-persist";
+RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
+
+const localStorage =
+  typeof window !== "undefined" ? window.localStorage : undefined;
+
+const { persistAtom } = recoilPersist({
+  key: "localStorage",
+  storage: localStorage,
+  converter: JSON,
+});
+
+export const userState = atom<userType>({
+  key: "userData",
+  default: {
+    user_email: "",
+    user_nickname: "",
+    user_resume: "",
+    user_uid: "",
+  },
+  effects_UNSTABLE: [persistAtom],
+});

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,6 +1,6 @@
 export interface userType {
   user_email: string;
   user_nickname: string;
-  user_resume: string;
+  user_resume?: string;
   user_uid: string;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,6 @@
+export interface userType {
+  user_email: string;
+  user_nickname: string;
+  user_resume: string;
+  user_uid: string;
+}


### PR DESCRIPTION
## 1. 해당 브랜치에서 작업한 내용
- 이메일 로그인
- 로그인한 유저 정보 가져오기
- 로그인 유무 확인 로직
- 회원가입 시 추가로 필요한 정보 유저 객체에 저장
- 로그인 만료시 자동 로그아웃
- 로그인/로그아웃 버튼 추가
- 탭 닫으면 자동 로그아웃

## 2. 작업한 결과물
- 

## 3. 해당 작업을 하면서 생겼던 이슈사항
- 로그인 시 유저정보를 로컬스토리지에 저장하고 유저 저장 여부에 따라 로그인/로그아웃 버튼을 다르게 보여줬는데 서버와 클라이언트에서의 ui가 달라서 hydration 에러가 났음 서버에서 매번 받아올 수 있지만 새로고침을 하더라도 정보가 저장이 되어있어야했기 때문에 로컬스토리지에 저장할 수 밖에 없었고 서버에서는 로컬스토리지에 접근 할 수 없어서 생겼던 오류라고 판단, 방법을 찾아보니 hydration warining을 무시하는 옵션이 있어 추가함.
   - 관련 자료 https://nextjs.org/docs/messages/react-hydration-error

## 4. 해당 작업을 통해 알게 된 내용
- hydration 오류 해결 방법
- 파이어베이스에서 로그인 및 로그인한 유저관리